### PR TITLE
modify data_cleaning.sh

### DIFF
--- a/bin/data_cleaning.sh
+++ b/bin/data_cleaning.sh
@@ -5,11 +5,16 @@
 # Prerequisites: install BBTools 38.49
 
 # 1. Create output directories 
-mkdir ../data/seq_clean
-mkdir ../data/seq_clean/R1
-mkdir ../data/seq_clean/R2
+mkdir ../data/clean
 
-# 2. Eliminate adapters
-for i in *.fastq.gz;
-do bbduk.sh -Xmx2g threads=1 in1=../data/R1/$i in2=../data/R2/$i out1=../data/seq_clean/R1/$i out2=../data/R2/$i ref=/resources/adapters.fa tpe tbo
+# 2. Create a vector containing the unique  pice of the file name (in word character) before the "_" 
+
+fileprefix=$(ls ../data | grep -oE "\w*"_ | uniq)
+
+# 3. Eliminate adapters
+
+for i in $fileprefix;
+do bbmap/bbduk.sh -Xmx2g threads=1 in1=../data/${R}1.fastq.gz in2=../data/${R}2.fastq.gz out1=../data/clean/${R}1.fastq.gz out2=../data/clean/${R}2.fastq.gz ref=/bbmap/resources/adapters.fa tpe tbo;
+done
+
 


### PR DESCRIPTION
new changes:
delete all extra mkdir
allow to create a arrange containing the file prefixes. so the last part of the file names in the command line contain 1 or 2 (ej. *1.fastq.gz)

IMPORTANT: raw data must be placed together in /data/
so the relative paths have been corrected

this solves corresponds to [issue](https://github.com/Melcatus/genomic_cotton/issues/4)

this was solved by Duhya, Hector, Alicia and me